### PR TITLE
add Reply-To header to email submission copy

### DIFF
--- a/src/Submission/MailHelper.php
+++ b/src/Submission/MailHelper.php
@@ -35,6 +35,7 @@ class MailHelper {
 		try {
 
 			$mail = App::mailer()->create();
+			$mail->getHeaders()->addTextHeader('Reply-To', $this->submission->email);
 			$mail->setTo($adminMail)->setSubject($mailSubject)->setBody(App::view('bixie/formmaker/mails/template.php', compact('mailBody')), 'text/html')->send();
 
 			if ($this->submission->email) {


### PR DESCRIPTION
One will be able to directly reply to an submission. No need anymore to
manually copy and paste the email address of the user to reply to a form
submission.

fixes #26 