### PR TITLE
Multiple email receivers depending on user selection

### DIFF
--- a/app/components/field-edit.vue
+++ b/app/components/field-edit.vue
@@ -33,7 +33,7 @@
                     <field-basic :field.sync="field" :type.sync="type" :roles="roles" :form="form"></field-basic>
                 </div>
                 <div v-if="type.hasOptions">
-                    <field-options :field.sync="field" :form="form"></field-options>
+                    <field-options :field.sync="field" :form="form" :type="type"></field-options>
                 </div>
                 <div>
                     <field-appearance :field.sync="field" :form="form"></field-appearance>

--- a/app/components/field-options.vue
+++ b/app/components/field-options.vue
@@ -6,7 +6,12 @@
             <span class="uk-form-label">{{ 'Manage options' | trans }}</span>
 
             <div class="uk-form-controls uk-form-controls-text">
-                <ul class="uk-nestable uk-margin-remove" v-el:options-nestable v-show="field.options.length">
+                <ul v-if="type.optionTypeEmail" class="uk-nestable uk-margin-remove" v-el:options-nestable v-show="field.options.length">
+                    <selectoption-email v-for="selectoption in field.options"
+                                  :selectoption.sync="selectoption"
+                                  :read-only="readOnly"></selectoption-email>
+                </ul>
+                <ul v-else class="uk-nestable uk-margin-remove" v-el:options-nestable v-show="field.options.length">
                     <selectoption v-for="selectoption in field.options"
                                   :selectoption.sync="selectoption"
                                   :read-only="readOnly"></selectoption>
@@ -24,16 +29,20 @@
 
     module.exports = {
 
-        props: ['field', 'form'],
+        props: ['field', 'form', 'type'],
 
         methods: {
             addFieldoption() {
-                this.field.options.push({
+                var options = {
                     value: '',
                     text: '',
                     attachValue: true,
                     invalid: false
-                });
+                };
+                if(this.type.optionTypeEmail) {
+                    options['email'] = '';
+                }
+                this.field.options.push(options);
                 this.$nextTick(() => $(this.$els.optionsNestable).find('input:last').focus());
             },
             deleteFieldoption(idx) {
@@ -88,7 +97,7 @@
 
             selectoption: {
 
-                template: '<li class="uk-nestable-item" data-value="{{ selectoption.value }}">\n    <div v-if="!readOnly" class="uk-nestable-panel uk-visible-hover uk-form uk-flex uk-flex-middle">\n        <div class="uk-flex-item-1">\n            <div class="uk-form-row">\n                <small class="uk-form-label uk-text-muted uk-text-truncate" style="text-transform: none"\n                       v-show="selectoption.attachValue"\n                       :class="{\'uk-text-danger\': selectoption.invalid}">{{ selectoption.value }}</small>\n                <span class="uk-form-label" v-show="!selectoption.attachValue">\n                    <input type="text" class="uk-form-small"\n                           @keyup="safeValue(true)"\n                           :class="{\'uk-text-danger\': selectoption.invalid}"\n                           v-model="selectoption.value"/></span>\n                <div class="uk-form-controls">\n                    <input type="text" class="uk-form-width-large" v-model="selectoption.text"/></div>\n                <p class="uk-form-help-block uk-text-danger" v-show="selectoption.invalid">{{ selectoption.invalid | trans }}</p>\n\n            </div>\n        </div>\n        <div class="">\n            <ul class="uk-subnav pk-subnav-icon">\n                <li><a class="uk-icon uk-margin-small-top pk-icon-hover uk-invisible"\n                       data-uk-tooltip="{delay: 500}" :title="\'Link/Unlink value from label\' | trans"\n                       :class="{\'uk-icon-link\': !selectoption.attachValue, \'uk-icon-chain-broken\': selectoption.attachValue}"\n                       @click.prevent="selectoption.attachValue = !selectoption.attachValue"></a></li>\n                <li><a class="pk-icon-delete pk-icon-hover uk-invisible" @click="$parent.deleteFieldoption(selectoption)"></a></li>\n                <li><a class="pk-icon-move pk-icon-hover uk-invisible uk-nestable-handle"></a></li>\n            </ul>\n        </div>\n    </div>\n    <div v-else>\n        {{ selectoption.text }}\n    </div>\n</li>   \n',
+                template: '<li class="uk-nestable-item" data-value="{{ selectoption.value }}">\n    <div v-if="!readOnly" class="uk-nestable-panel uk-visible-hover uk-form uk-flex uk-flex-middle">\n        <div class="uk-flex-item-1">\n            <div class="uk-form-row">\n                <small class="uk-form-label uk-text-muted uk-text-truncate" style="text-transform: none"\n                       v-show="selectoption.attachValue"\n                       :class="{\'uk-text-danger\': selectoption.invalid}">{{ selectoption.value }}</small>\n                <span class="uk-form-label" v-show="!selectoption.attachValue">\n                    <input type="text" class="uk-form-small"\n                           @keyup="safeValue(true)"\n                           :class="{\'uk-text-danger\': selectoption.invalid}"\n                           v-model="selectoption.value"/></span>\n                <div class="uk-form-controls">\n                    <input type="text" class="uk-form-width-large" v-model="selectoption.text"/>\n                </div>\n                <p class="uk-form-help-block uk-text-danger" v-show="selectoption.invalid">{{ selectoption.invalid | trans }}</p>\n            </div>\n        </div>\n        <div class="">\n            <ul class="uk-subnav pk-subnav-icon">\n                <li><a class="uk-icon uk-margin-small-top pk-icon-hover uk-invisible"\n                       data-uk-tooltip="{delay: 500}" :title="\'Link/Unlink value from label\' | trans"\n                       :class="{\'uk-icon-link\': !selectoption.attachValue, \'uk-icon-chain-broken\': selectoption.attachValue}"\n                       @click.prevent="selectoption.attachValue = !selectoption.attachValue"></a></li>\n                <li><a class="pk-icon-delete pk-icon-hover uk-invisible" @click="$parent.deleteFieldoption(selectoption)"></a></li>\n                <li><a class="pk-icon-move pk-icon-hover uk-invisible uk-nestable-handle"></a></li>\n            </ul>\n        </div>\n    </div>\n    <div v-else>\n        {{ selectoption.text }}\n    </div>\n</li>\n',
 
                 props: ['selectoption', 'readOnly'],
 
@@ -109,6 +118,47 @@
                         this.$parent.checkDuplicates();
                     }
 
+                }
+            },
+
+            'selectoption-email': {
+
+                template: '<li v-validator="validateSelectoption" class="uk-nestable-item" data-value="{{ selectoption.value }}">\n    <div v-if="!readOnly" class="uk-nestable-panel uk-visible-hover uk-form uk-flex uk-flex-middle">\n        <div class="uk-flex-item-1">\n            <div class="uk-form-row">\n                <span class="uk-form-label">{{ "Value" | trans }}</span>\n                <div class="uk-form-controls">\n                    <input :disabled="selectoption.attachValue" type="text" class="uk-form-width-large" @keyup="safeValue(true)" :class="{\'uk-text-danger\': selectoption.invalid}" v-model="selectoption.value"/>\n                <p class="uk-form-help-block uk-text-danger" v-show="selectoption.invalid">{{ selectoption.invalid | trans }}</p>\n                </div>\n                <span class="uk-form-label">{{ "Label" | trans }}</span>\n                <div class="uk-form-controls">                    <input type="text" class="uk-form-width-large" v-model="selectoption.text"/>\n                    </div>\n                <span class="uk-form-label">{{ "Email" | trans }}</span>\n                <div class="uk-form-controls">\n                    <input name="email" type="email" class="uk-form-width-large" v-model="selectoption.email" :class="{\'uk-text-danger\': invalidEmail}" v-validate:required="true" v-validate:email/>\n                    <p class="uk-form-help-block uk-text-danger" v-show="invalidEmail">{{ invalidEmail | trans }}</p>\n                </div>\n            </div>\n        </div>\n        <div class="">\n            <ul class="uk-subnav pk-subnav-icon">\n                <li><a class="uk-icon uk-margin-small-top pk-icon-hover uk-invisible" data-uk-tooltip="{delay: 500}" :title="\'Link/Unlink value from label\' | trans" :class="{\'uk-icon-link\': !selectoption.attachValue, \'uk-icon-chain-broken\': selectoption.attachValue}" @click.prevent="toggleAttachValue()"></a></li>\n                <li><a class="pk-icon-delete pk-icon-hover uk-invisible" @click="$parent.deleteFieldoption(selectoption)"></a></li>\n                <li><a class="pk-icon-move pk-icon-hover uk-invisible uk-nestable-handle"></a></li>\n            </ul>\n        </div>\n    </div>\n    <div v-else>\n        {{ selectoption.text }}\n    </div>\n</li>\n',
+
+                props: ['selectoption', 'readOnly'],
+
+                methods: {
+                    safeValue(checkDups) {
+                        this.selectoption.value = _.escape(_.snakeCase(this.selectoption.value));
+                        if (checkDups) {
+                            this.$parent.checkDuplicates();
+                        }
+                    },
+                    checkAttachValue() {
+                        if (this.selectoption.attachValue) {
+                            this.selectoption.value = this.selectoption.text;
+                        }
+                        this.safeValue(true);
+                    },
+                    toggleAttachValue() {
+                        this.selectoption.attachValue = !this.selectoption.attachValue;
+                        this.checkAttachValue();
+                    }
+                },
+
+                computed: {
+                    invalidEmail: function() {
+                        if(this.validateSelectoption) {
+                            return this.validateSelectoption.email.invalid ? 'Please enter a valid email address' : false;
+                        }
+                        return false;
+                    }
+                },
+
+                watch: {
+                    "selectoption.text"(value) {
+                        this.checkAttachValue();
+                    }
                 }
             }
 

--- a/app/components/form-email.vue
+++ b/app/components/form-email.vue
@@ -10,7 +10,7 @@
                     <div class="uk-form-controls">
                         <select id="form-user_email_field" class="uk-form-width-medium" v-model="formitem.data.user_email_field">
                             <option value="">{{ 'Select a field' | trans }}</option>
-                            <option v-for="field in formfields | filterBy 'email' in 'type'" :value="field.slug">{{ field.label }}</option>
+                            <option v-for="field in userEmailFields" :value="field.slug">{{ field.label }}</option>
                         </select>
                     </div>
                 </div>
@@ -31,19 +31,40 @@
                     {{ 'No email field is selected for user confirmation mail.' | trans }}</div>
 
                 <div class="uk-form-row">
-                    <label for="form-submitemail" class="uk-form-label">{{ 'Email copy of submission to' | trans }}</label>
+                    <label class="uk-form-label">{{ 'Email receiver' | trans }}</label>
 
                     <div class="uk-form-controls">
-                        <input id="form-submitemail" class="uk-form-width-large" type="text" name="submitemail"
-                               v-model="formitem.data.submitEmail" v-validate:email v-validate:required="!!formitem.data.user_email_field">
-                    <!-- //todo fix req message -->
-                    <p class="uk-form-help-block uk-text-danger" v-show="form.submitemail.invalid">{{ 'Please enter valid email address' | trans }}</p>
-
-                    <p class="uk-form-help-block uk-text-danger" v-show="formitem.data.user_email_field && !formitem.data.submitEmail">
-                        {{ 'No email will be sent to the user when no address is entered here!' | trans }}</p>
+                        <label>
+                            <input type="checkbox" value="submitemailtype"
+                                  v-model="formitem.data.submitEmailMultiple"> {{ 'User can choose email receiver from email pulldown' | trans }}</label>
+                    </div>
                 </div>
-            </div>
 
+                <div class="uk-form-row">
+                    <label for="form-submitemail" class="uk-form-label">{{ 'Email copy of submission to' | trans }}</label>
+
+                    <div v-show="!formitem.data.submitEmailMultiple" class="uk-form-controls">
+                        <input id="form-submitemail" class="uk-form-width-large" type="text" name="submitemail"
+                               v-model="formitem.data.submitEmail" v-validate:email v-validate:required="!!formitem.data.user_email_field && !formitem.data.submitEmailMultiple">
+	                    <!-- //todo fix req message -->
+	                    <p class="uk-form-help-block uk-text-danger" v-show="form.submitemail.invalid">{{ 'Please enter valid email address' | trans }}</p>
+
+	                    <p class="uk-form-help-block uk-text-danger" v-show="formitem.data.user_email_field && !formitem.data.submitEmail">
+	                        {{ 'No email will be sent to the user when no address is entered here!' | trans }}</p>
+	                </div>
+
+                    <div v-show="formitem.data.submitEmailMultiple" class="uk-form-controls">
+                        <select id="form-submitemailfield" class="uk-form-width-medium" v-model="formitem.data.submitEmailField">
+                            <option value="">{{ 'Select a field' | trans }}</option>
+                            <option v-for="field in submitEmailFields" :value="field.slug">{{ field.label }}</option>
+                        </select>
+                        <!-- Validate that there was a selection made -->
+                        <input type="hidden" v-model="formitem.data.submitEmailField" name="submitemailfield" v-validate:required="!!formitem.data.user_email_field && formitem.data.submitEmailMultiple" />
+
+	                    <p class="uk-form-help-block uk-text-danger" v-show="formitem.data.user_email_field && !formitem.data.submitEmailField">
+	                        {{ 'No email will be sent to the user when no email receiver field is selected here!' | trans }}</p>
+                    </div>
+                </div>
 
                 <div class="uk-form-row">
                     <label for="form-emailsubject" class="uk-form-label">{{ 'Email subject' | trans }}</label>
@@ -80,6 +101,20 @@
     module.exports = {
 
         props: ['formitem', 'formfields', 'form'],
+
+        computed: {
+            userEmailFields () {
+                return this.formfields.filter((field)  => {
+                    return field.type === 'email'
+                })
+            },
+
+            submitEmailFields () {
+                return this.formfields.filter((field)  => {
+                    return field.type === 'emailpulldown'
+                })
+            }
+        },
 
         components: {
             formfieldslist: require('./form-fieldslist.vue')

--- a/app/views/admin/edit.js
+++ b/app/views/admin/edit.js
@@ -10,6 +10,8 @@ module.exports = {
                     classSfx: '',
                     user_email_field: false,
                     submitEmail: window.$data.config.from_address,
+                    submitEmailMultiple: false,
+                    submitEmailField: '',
                     email_subject: this.$trans('Thank you for your submission'),
                     thankyou_markdown: true,
                     email_body_markdown: true,

--- a/src/Model/Field.php
+++ b/src/Model/Field.php
@@ -50,6 +50,14 @@ class Field extends FieldBase implements \JsonSerializable {
 	public function jsonSerialize () {
 		$field = $this->toArray([], ['fieldValue', 'fieldType']);
 		$field['options'] = $this->getOptions();
+		if (is_array($field['options']) && !App::user()->isAdministrator()) {
+		    $fieldOptions = [];
+		    foreach ($field['options'] as $fieldOption) {
+		        unset($fieldOption['email']);
+		        $fieldOptions[] = $fieldOption;
+		    }
+		    $field['options'] = $fieldOptions;
+		}
 		return $field;
 	}
 

--- a/src/Model/Submission.php
+++ b/src/Model/Submission.php
@@ -103,6 +103,25 @@ class Submission implements \JsonSerializable {
 		return '';
 	}
 
+    public function getAdminEmail () {
+        $this->getFieldsubmissions();
+        if ($this->form->get('submitEmailMultiple')) {
+            $submitEmailSubmission = $this->fieldsubmissions[$this->form->get('submitEmailField')];
+            if (isset($submitEmailSubmission)
+                and $selectionValue = count($submitEmailSubmission['value']) ? $submitEmailSubmission['value'][0] : ''
+                and $submitEmailField = $submitEmailSubmission['field']) {
+                foreach ($submitEmailField['options'] as $submitEmailOption) {
+                    if ($submitEmailOption['value'] == $selectionValue) {
+                        return $submitEmailOption['email'];
+                    }
+                }
+            }
+        } else {
+            return $this->form->get('submitEmail');
+        }
+        return '';
+    }
+
 	public function getFieldsubmissions () {
 		if (!isset($this->fieldsubmissions)) {
 			$fields = $this->form->getFields();

--- a/src/Submission/MailHelper.php
+++ b/src/Submission/MailHelper.php
@@ -26,7 +26,7 @@ class MailHelper {
 	 * @return MailHelper
 	 */
 	public function sendMail () {
-		if (!$adminMail = $this->submission->form->get('submitEmail')) {
+		if (!$adminMail = $this->submission->getAdminEmail()) {
 			return $this;
 		}
 		$user_email = $this->submission->email ? : false;


### PR DESCRIPTION
The administrator gets a new option to provide an email for sending the form. It is possible to specify whether a page visitor can select from a list of predefined email receivers or not. If the page visitor can not decide anything, the behavior is the same as now. If the page visitor can decide who should receive the email, an email pulldown field needs to be added to the form. This field then provides the possibility to the page visitor to select a receiver from the list.

Requires Bixie/pk-framework#1
Resolves #18.